### PR TITLE
Fix bug preventing encoding pointer to time.Time

### DIFF
--- a/query/encode.go
+++ b/query/encode.go
@@ -217,16 +217,16 @@ func reflectValue(values url.Values, val reflect.Value, scope string) error {
 			continue
 		}
 
-		if sv.Type() == timeType {
-			values.Add(name, valueString(sv, opts))
-			continue
-		}
-
 		for sv.Kind() == reflect.Ptr {
 			if sv.IsNil() {
 				break
 			}
 			sv = sv.Elem()
+		}
+
+		if sv.Type() == timeType {
+			values.Add(name, valueString(sv, opts))
+			continue
 		}
 
 		if sv.Kind() == reflect.Struct {

--- a/query/encode_test.go
+++ b/query/encode_test.go
@@ -25,6 +25,8 @@ type SubNested struct {
 func TestValues_types(t *testing.T) {
 	str := "string"
 	strPtr := &str
+	tym := time.Date(2000, 1, 1, 12, 34, 56, 0, time.UTC)
+	tymPtr := &tym
 
 	tests := []struct {
 		in   interface{}
@@ -107,19 +109,22 @@ func TestValues_types(t *testing.T) {
 			struct {
 				A time.Time
 				B time.Time `url:",unix"`
-				C bool      `url:",int"`
-				D bool      `url:",int"`
+				C *time.Time
+				D bool `url:",int"`
+				E bool `url:",int"`
 			}{
-				A: time.Date(2000, 1, 1, 12, 34, 56, 0, time.UTC),
-				B: time.Date(2000, 1, 1, 12, 34, 56, 0, time.UTC),
-				C: true,
-				D: false,
+				A: tym,
+				B: tym,
+				C: tymPtr,
+				D: true,
+				E: false,
 			},
 			url.Values{
 				"A": {"2000-01-01T12:34:56Z"},
 				"B": {"946730096"},
-				"C": {"1"},
-				"D": {"0"},
+				"C": {"2000-01-01T12:34:56Z"},
+				"D": {"1"},
+				"E": {"0"},
 			},
 		},
 		{


### PR DESCRIPTION
The encoder handles the case where a field is of type
time.Time. Additionally, non-nil pointer values are encoded as the
value pointed to by drilling down to the element the pointer field
references. However, the ordering of which this was done was
preventing the combination of the two from working.
